### PR TITLE
Security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We ask that you not open a GitHub Issue for help, only for bug reports.
 
 **Reporting Security Issues**
 
-Please have a look at SECURITY.md.
+Please have a look at [SECURITY.md](SECURITY.md).
 
 How Can I Contribute?
 ==================================

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,4 +4,4 @@
 
 In case you think to have found a security issue, please do not
 open a public issue.  Instead, you can report the issue to the private mailing
-list [security@TBC.com](mailto:security@TBC.com). We will try to clarify further steps.
+list [security@devopsgroup.com](mailto:security@devopsgroup.com). We will try to clarify further steps.


### PR DESCRIPTION
- Add a link from the README to the SECURITY page
- Change the security contact email from `security@TBC.com` to `security@devopsgroup.com`