### PR TITLE
Add PRR team as the codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @devopsguys/production-readiness-review-team


### PR DESCRIPTION
This will add the PRR team as [codeowners](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) of the repo.

This resolves #17 
